### PR TITLE
Searched movie card 구성

### DIFF
--- a/src/constants/movie.ts
+++ b/src/constants/movie.ts
@@ -1,5 +1,5 @@
 export enum MovieType {
-  CGV = 'CGV',
-  LOTTE = 'Lotte',
-  MEGABOX = 'MegaBox',
+  CGV = 'cgv',
+  LOTTE = 'lotte',
+  MEGABOX = 'megaBox',
 }

--- a/src/containers/MainMovies/index.tsx
+++ b/src/containers/MainMovies/index.tsx
@@ -20,7 +20,7 @@ const MainMoviesContainer = () => {
   // dummy data
   const { loading, error, data } = {
     loading: false,
-    error: 'Error',
+    error: null,
     data: dummy,
   };
   // const { loading, error, data } = useQuery(GET_BOXOFFICE_QUERY);

--- a/src/containers/SearchedMovies/index.tsx
+++ b/src/containers/SearchedMovies/index.tsx
@@ -112,6 +112,9 @@ const SearchedMoviesContainer = () => {
   }, [nearByTheaters]);
 
   if (nearByTheaters) {
+    // TODO nearyByTheaters 에 찾은 영화 정보들은 다 API 콜해서 각각 타임 테이블 가져와서 렌더링
+    // TheaterTimeTable은 하나의 nearByTheater 에만 반응
+    // 또한 가공이 필요한데... 시간 별로 정렬이 필요...
     return <TheaterTimeTable theaterInfo={nearByTheaters[0]} />;
   }
 

--- a/src/containers/SearchedMovies/index.tsx
+++ b/src/containers/SearchedMovies/index.tsx
@@ -1,23 +1,21 @@
-import SearchedMovies from 'components/card/SearchedMovies';
+import { Loading } from 'components/Loading';
+import { MovieType } from 'constants/movie';
 import dummy from 'dummy/searchedMovieCards';
 import { ISearchedMovieCard } from 'interfaces/card';
-import React, { useEffect, useState, useCallback } from 'react';
-
+import { TheaterInfo } from 'interfaces/theater';
 import { THEATERS as cgvTheaters } from 'lib/datum/theaters/cgv';
 import { THEATERS as lotteTheaters } from 'lib/datum/theaters/lotte';
 import { THEATERS as megaTheaters } from 'lib/datum/theaters/megaBox';
-import { MovieType } from 'constants/movie';
+import React, { useCallback, useEffect, useState } from 'react';
+import TheaterTimeTable from 'containers/TheaterTimeTable';
 
 const NEARBY_KM = 3;
 
 const SearchedMoviesContainer = () => {
   // Default is seoul city hall
-  const [nowPosition, setNowPosition] = useState({
-    lat: 37.566,
-    lng: 126.9784,
-  });
-  const [nearByTheaters, setNearByTheaters] = useState([]);
-  const [movies, setMovies] = useState<ISearchedMovieCard[]>([]);
+  const [nowPosition, setNowPosition] = useState(null);
+  const [nearByTheaters, setNearByTheaters] = useState<TheaterInfo[]>(null);
+  const [movies, setMovies] = useState<ISearchedMovieCard[]>(null);
 
   const getLocation = useCallback(() => {
     if (navigator.geolocation) {
@@ -41,7 +39,7 @@ const SearchedMoviesContainer = () => {
     } else {
       alert('위치 정보를 지원하지 않습니다.');
     }
-  }, []);
+  }, [navigator.geolocation]);
 
   const arePointsNear = useCallback(
     (checkPoint) => {
@@ -55,65 +53,69 @@ const SearchedMoviesContainer = () => {
   );
 
   useEffect(() => {
-    setMovies(dummy);
-  }, []);
-
-  useEffect(() => {
     getLocation();
   }, []);
 
   useEffect(() => {
-    const theaterList = [];
-    // eslint-disable-next-line no-restricted-syntax
-    for (const theaters of cgvTheaters) {
+    if (nowPosition) {
+      const theaterList = [];
       // eslint-disable-next-line no-restricted-syntax
-      for (const theater of theaters) {
-        const { location } = theater;
-        if (arePointsNear(location)) {
-          theaterList.push({
-            ...theater,
-            type: MovieType.CGV,
-          });
+      for (const theaters of cgvTheaters) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const theater of theaters) {
+          const { location } = theater;
+          if (arePointsNear(location)) {
+            theaterList.push({
+              ...theater,
+              type: MovieType.CGV,
+            });
+          }
         }
       }
-    }
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const theaters of lotteTheaters) {
       // eslint-disable-next-line no-restricted-syntax
-      for (const theater of theaters) {
-        const { location } = theater;
-        if (arePointsNear(location)) {
-          theaterList.push({
-            ...theater,
-            type: MovieType.LOTTE,
-          });
+      for (const theaters of lotteTheaters) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const theater of theaters) {
+          const { location } = theater;
+          if (arePointsNear(location)) {
+            theaterList.push({
+              ...theater,
+              type: MovieType.LOTTE,
+            });
+          }
         }
       }
-    }
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const theaters of megaTheaters) {
       // eslint-disable-next-line no-restricted-syntax
-      for (const theater of theaters) {
-        const { location } = theater;
-        if (arePointsNear(location)) {
-          theaterList.push({
-            ...theater,
-            type: MovieType.MEGABOX,
-          });
+      for (const theaters of megaTheaters) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const theater of theaters) {
+          const { location } = theater;
+          if (arePointsNear(location)) {
+            theaterList.push({
+              ...theater,
+              type: MovieType.MEGABOX,
+            });
+          }
         }
       }
+      setNearByTheaters(theaterList);
     }
-    setNearByTheaters(theaterList);
   }, [nowPosition]);
 
   useEffect(() => {
-    console.log("nearByTheaters", nearByTheaters);
-    // TODO: Get movie time table api
+    if (nearByTheaters) {
+      console.log('Near by theaters', nearByTheaters);
+      setMovies(dummy);
+    }
   }, [nearByTheaters]);
 
-  return <SearchedMovies movies={movies} />;
+  if (nearByTheaters) {
+    return <TheaterTimeTable theaterInfo={nearByTheaters[0]} />;
+  }
+
+  return <Loading />;
 };
 
 export default SearchedMoviesContainer;

--- a/src/containers/TheaterTimeTable/index.tsx
+++ b/src/containers/TheaterTimeTable/index.tsx
@@ -1,0 +1,42 @@
+import { gql } from 'apollo-boost';
+import { TheaterInfo } from 'interfaces/theater';
+import React, { useEffect } from 'react';
+import { useQuery } from 'react-apollo';
+import { ISearchedMovieCard } from 'interfaces/card';
+
+interface TheaterTimeTableProps {
+  theaterInfo: TheaterInfo;
+  onSetMovies?: (movieCard: ISearchedMovieCard) => void;
+}
+
+const GET_TIMETABLE_QUERY = gql`
+  query TimeTable($type: String!, $link: String!) {
+    timeTable(type: $type, theaterLink: $link) {
+      title
+      timeInfo {
+        time
+      }
+    }
+  }
+`;
+
+const TheaterTimeTable: React.FunctionComponent<TheaterTimeTableProps> = ({
+  theaterInfo,
+  onSetMovies,
+}: TheaterTimeTableProps) => {
+  const { type, link } = theaterInfo;
+  const { loading, error, data } = useQuery(GET_TIMETABLE_QUERY, {
+    variables: { type, link },
+  });
+
+  useEffect(() => {
+    if (loading || error) {
+      return;
+    }
+
+  }, [loading, error, data.timeTable]);
+
+  return <></>;
+};
+
+export default TheaterTimeTable;

--- a/src/containers/TheaterTimeTable/index.tsx
+++ b/src/containers/TheaterTimeTable/index.tsx
@@ -49,6 +49,9 @@ const TheaterTimeTable: React.FunctionComponent<TheaterTimeTableProps> = ({
         location: title,
         title: tableTitle,
         time: info.time,
+        // TODO:
+        // Image도 어떻게 할지 생각을 해봐야겠다.
+        // 지금 타임 테이블에 대해서는 이미지를 가지고 오지 않는데... 큰일이네
         image: 'http://www.kobis.or.kr/common/mast/movie/2020/01/a880f5d250f04e6bacc786342972ddf4.jpg',
       }),
     );

--- a/src/containers/TheaterTimeTable/index.tsx
+++ b/src/containers/TheaterTimeTable/index.tsx
@@ -1,42 +1,60 @@
 import { gql } from 'apollo-boost';
 import { TheaterInfo } from 'interfaces/theater';
 import React, { useEffect } from 'react';
-import { useQuery } from 'react-apollo';
+// import { useQuery } from 'react-apollo';
 import { ISearchedMovieCard } from 'interfaces/card';
+import timeTableDummy from 'dummy/timetable';
+import SearchedMovies from 'components/card/SearchedMovies';
 
 interface TheaterTimeTableProps {
   theaterInfo: TheaterInfo;
   onSetMovies?: (movieCard: ISearchedMovieCard) => void;
 }
 
-const GET_TIMETABLE_QUERY = gql`
-  query TimeTable($type: String!, $link: String!) {
-    timeTable(type: $type, theaterLink: $link) {
-      title
-      timeInfo {
-        time
-      }
-    }
-  }
-`;
+// const GET_TIMETABLE_QUERY = gql`
+//   query TimeTable($type: String!, $link: String!) {
+//     timeTable(type: $type, theaterLink: $link) {
+//       title
+//       timeInfo {
+//         time
+//       }
+//     }
+//   }
+// `;
 
 const TheaterTimeTable: React.FunctionComponent<TheaterTimeTableProps> = ({
   theaterInfo,
   onSetMovies,
 }: TheaterTimeTableProps) => {
-  const { type, link } = theaterInfo;
-  const { loading, error, data } = useQuery(GET_TIMETABLE_QUERY, {
-    variables: { type, link },
+  const { title, type, link } = theaterInfo;
+  const { loading, error, data } = {
+    loading: false,
+    error: null,
+    data: timeTableDummy,
+  };
+  // const { loading, error, data } = useQuery(GET_TIMETABLE_QUERY, {
+  //   variables: { type, link },
+  // });
+
+  if (loading || error) {
+    return null;
+  }
+  const { timeTable } = timeTableDummy;
+  const movies = timeTable.flatMap((table, index) => {
+    const { title: tableTitle, timeInfo } = table;
+    return timeInfo.map(
+      (info, timeIndex): ISearchedMovieCard => ({
+        id: `${index}-${timeIndex}`,
+        type,
+        location: title,
+        title: tableTitle,
+        time: info.time,
+        image: 'http://www.kobis.or.kr/common/mast/movie/2020/01/a880f5d250f04e6bacc786342972ddf4.jpg',
+      }),
+    );
   });
 
-  useEffect(() => {
-    if (loading || error) {
-      return;
-    }
-
-  }, [loading, error, data.timeTable]);
-
-  return <></>;
+  return <SearchedMovies movies={movies} />;
 };
 
 export default TheaterTimeTable;

--- a/src/dummy/timetable.ts
+++ b/src/dummy/timetable.ts
@@ -1,0 +1,38 @@
+const datam = {
+  timeTable: [
+    {
+      title: '에이비',
+      timeInfo: [{ time: '13:40' }, { time: '17:50' }, { time: '22:00' }],
+    },
+    {
+      title: '테넷',
+      timeInfo: [
+        { time: '15:40' },
+        { time: '17:50' },
+        { time: '22:00' },
+        { time: '23:30' },
+      ],
+    },
+    {
+      title: '오! 문희',
+      timeInfo: [
+        { time: '12:40' },
+        { time: '14:50' },
+        { time: '16:10' },
+        { time: '17:30' },
+        { time: '18:10' },
+        { time: '19:30' },
+      ],
+    },
+    {
+      title: '뉴 뮤턴트',
+      timeInfo: [{ time: '12: 40' }, { time: '17: 50' }, { time: '22:00' }],
+    },
+    {
+      title: '다만 악에서 구하소서',
+      timeInfo: [{ time: '16: 40' }],
+    },
+  ],
+};
+
+export default datam;

--- a/src/interfaces/theater.ts
+++ b/src/interfaces/theater.ts
@@ -1,0 +1,11 @@
+import { MovieType } from 'constants/movie';
+
+export interface TheaterInfo {
+  type: MovieType;
+  title?: string;
+  link: string;
+  location?: {
+    lat: number;
+    lng: number;
+  };
+}


### PR DESCRIPTION
- TODO
    - 카드 별로 이미지가 없는데 이를 어떻게 처리할지?
    - 카드를 시간별로 정리해야할텐데 이를 어떻게 할지?
 
- 지금은 그냥 더미데이터를 이용해 보여주기만 함
- 대략적인 비지니스 로직을 구현함

- containers/SearhcedMovies
    - location기반으로 lib/datum에 있는 영화관을 찾아옴
    - 영화관을 찾아오면 각 영화관 별로 containers/TheaterTimeTable 에서 각각의 타임 테이블을 요청함 (이때 이미지가 없이 시간만 줌)
    - 각 영화관 별로 각 영화들이 시간표를 가지고 데이터가 넘어옴 이를 정리해야하는데 현재 PR에는 location기반으로 찾은 영화관 하나에 대한 로직만 dummy 로 구현함